### PR TITLE
Update for swagger-client 2.1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/app.js
+++ b/app.js
@@ -1,9 +1,6 @@
 var express = require('express');
 var client = require('swagger-client');
 
-//use your private token here, since we're talking server-server
-client.authorizations.add("apiKey", new client.ApiKeyAuthorization("private_token", "SamplePrivateTestKey1", "query"));
-
 var app = express();
 app.get('/stripe', function index(req, res){
     taxamo.apis.transactions.getTransaction({key: req.query.transaction_key}, function(data) {
@@ -35,3 +32,6 @@ var taxamo = new client.SwaggerApi({
     }
   }
 });
+
+//use your private token here, since we're talking server-server
+taxamo.clientAuthorizations.add('apiKey', new client.ApiKeyAuthorization('private_token', 'SamplePrivateTestKey1', 'query'));

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
   "private": true,
   "dependencies": {
     "express": "3.x",
-    "swagger-client": "2.x"
+    "swagger-client": "2.1.x"
   }
 }


### PR DESCRIPTION
There has been an incompatible change between swagger-client 2.0 and 2.1. The package.json specifies swagger-client's version as "2.x" so now "npm install" installs swagger-client 2.1.x. Running app.js then ends with "TypeError: Cannot call method 'add' of undefined". This pull request updates app.js to work with swagger 2.1.x and specifies the required version as "2.1.x" to avoid similar issues in the future. I also added .gitignore to ignore node_modules.

Btw. there's a related documentation issue in swagger-client: https://github.com/swagger-api/swagger-js/issues/401
